### PR TITLE
remove SelectFunctionsSeq

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,27 +63,6 @@ SelectFunctions.applyAll(hi, 1, 2d)(functions) == 2 :: "hi + 1" :: 2 :: HNil
 SelectFunctions.applyAll(hi, 'a', 1)(functions) == "hi + 1" :: 1.0 :: 101 :: 2 :: 97 :: HNil
 ```
 
-#### `SelectFunctionsSeq[L <: HList, FF <: HList]`
-
-Takes an `HList` `FF` of functions, which all return the same type `R`, and an `HList` of potential arguments `Context`. It applies the arguments to the functions for which all the arguments are present. It return an `Seq[R]` with the results.
-
-#### example
-
-```scala
-val functions =
-    { (x: String, i: Int) => ("feature1" -> (x.size + i)) } ::
-      { (x: String, i: Int) => ("feature2" -> i) } ::
-      { (x: String, s: Char, i: Int) => ("feature3" -> (s.toInt + i + x.size)) } ::
-      { (x: String, s: Char, i: Int) => ("feature4" -> (s.toInt + i * 2 + x.size)) } ::
-      HNil
-
-SelectFunctionsSeq.applyAll(hi)(functions).isEmpty
-SelectFunctionsSeq.applyAll(hi, 1)(functions) == Seq("feature1" -> 3, "feature2" -> 1)
-// an extra argument makes no difference if there are no functions that use it
-SelectFunctionsSeq.applyAll(hi, 1, 2d)(functions) == Seq("feature1" -> 3, "feature2" -> 1)
- ```
-
-
 #### `FlattenFunctions[Context <: HList, FFF <: HList]` 
 
 Takes an `HList` of `HLists` of functions and an `HList` of potential arguments, and uses `SelectFunctions[Context, FF]` to calculate the resulting `HList`.
@@ -105,30 +84,6 @@ val functions = functions1 ::
       HNil
 
 FlattenFunctions.applyAll(1, "a")(functions) === 2 :: 1.0 :: HNil
-```
-
-
-#### `FlattenFunctionsSeq[Context <: HList, FFF <: HList]`
-
-Takes an `HList` of `HLists` of functions and an `HList` of potential arguments, and uses `SelectFunctionsSeq[Context, FF]` to calculate `Seq[R]`. Meaning all functions most return the same type `R`.
-
-#### example
-
-```scala
-val functions1 =
-      { (x: String, i: Int) => (x.size + i) } ::
-        { (x: String, s: Char, i: Int) => (s.toInt + i * 2 + x.size) } ::
-        HNil
-val functions2 =
-      { (x: String, s: Char, i: Int) => (s.toInt + i + x.size) } ::
-        { (i: Int) => i } ::
-        HNil
-
-val functions = functions1 ::
-      functions2 ::
-      HNil
-
-FlattenFunctionsSeq.applyAll(1, "a")(functions) === Seq(2, 1)
 ```
 
 #### `EqualsIgnoringFields[T]`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ object MyBuild extends Build{
   val projectName = "typeless"
   lazy val aRootProject = Project(id = projectName, base = file("."),
     settings = Seq(
-      version := "0.2.5",
+      version := "0.3.0",
       name := projectName,
       scalaVersion := "2.11.8",
       description := "It provides some extra shapeless functionallity",

--- a/src/test/scala/crunch.scala
+++ b/src/test/scala/crunch.scala
@@ -24,25 +24,6 @@ import typeless.hlist._
 
 class CrunchTests extends FunSuite with Matchers {
 
-  test("FlattenFunctionsSeq") {
-    val functions1 =
-      { (x: String, i: Int) => (x.size + i) } ::
-        { (x: String, s: Char, i: Int) => (s.toInt + i * 2 + x.size) } ::
-        HNil
-    val functions2 =
-      { (x: String, s: Char, i: Int) => (s.toInt + i + x.size) } ::
-        { (i: Int) => i } ::
-        HNil
-
-    val functions = functions1 ::
-      functions2 ::
-      HNil
-    val res: Seq[Int] = FlattenFunctionsSeq.applyAll(1, "a")(functions)
-    assert(
-      res === Seq(2, 1)
-    )
-  }
-
   test("FlattenFunctions") {
     val functions1 =
       { (x: String, i: Int) => (x.size + i) } ::
@@ -118,11 +99,6 @@ class CrunchTests extends FunSuite with Matchers {
       ls ::
       ls ::
       HNil
-
-  test("apply all") {
-    val res: Seq[String] = FlattenFunctionsSeq.applyAll(1, "a")(all)
-    assert(res.distinct === Seq("1 + a"))
-  }
 
   test("apply all Hlist") {
     val res = FlattenFunctions.applyAll(1, "a")(all)

--- a/src/test/scala/selectFunctionsSeq.scala
+++ b/src/test/scala/selectFunctionsSeq.scala
@@ -31,35 +31,31 @@ class ApplyAllSeqsTests extends FunSuite with Matchers {
       HNil
 
   val hi = "hi"
-  test("single argument") {
-    assert(
-      SelectFunctionsSeq.applyAll(hi)(functions).isEmpty
-    )
-  }
+
   test("two arguments") {
     assert(
-      SelectFunctionsSeq.applyAll(hi, 1)(functions) === Seq("feature1" -> 3, "feature2" -> 1)
+      SelectFunctions.applyAll(hi, 1)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
     )
   }
   test("three arguments") {
     assert(
-      SelectFunctionsSeq.applyAll(hi, 1, 2d)(functions) === Seq("feature1" -> 3, "feature2" -> 1)
+      SelectFunctions.applyAll(hi, 1, 2d)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
     )
   }
   test("different three arguments") {
     assert(
-      SelectFunctionsSeq.applyAll(hi, 'a', 1)(functions) === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
+      SelectFunctions.applyAll(hi, 'a', 1)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
     )
   }
   test("four arguments in different order") {
     // the order of the arguments doesn't matter
     assert(
-      SelectFunctionsSeq.applyAll(hi, 2d, 1, 'a')(functions) === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
+      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
     )
   }
   test("can call with hlist") {
     assert(
-      SelectFunctionsSeq.applyAll(hi :: 1 :: HNil)(functions) == Seq("feature1" -> 3, "feature2" -> 1)
+      SelectFunctions.applyAll(hi :: 1 :: HNil)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
     )
   }
 


### PR DESCRIPTION
SelectFunctions returns an HList, that can be converted to a Seq[R], so
it's better to express the former `SelectFunctionsSeq` in terms of
`SelectFunctions`