### PR TITLE
transform SelectFunctions in a total function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For a `Seq` of Coproducts `C`, convert to `HList` of type `L`
 
 #### `SelectFunctions[L <: HList, FF <: HList]`
 
-Takes an `HList` of functions `FF` and an `HList` of potential arguments `Context`. It applies the arguments to the functions for which all the arguments are present. It returns an `HList` with the results
+Takes an `HList` of functions `FF` and an `HList` of potential arguments `Context`. It applies the arguments to the functions for which all the arguments are present. It returns an `HList` with the results. It will *not compile* if there is a function that cannot be applied.
 
 #### example
 
@@ -58,8 +58,7 @@ val functions =
       { (x: Char) => x.toInt } ::
       HNil
 
-SelectFunctions.applyAll(1, hi)(functions) == "hi + 1" :: 2 :: HNil
-SelectFunctions.applyAll(hi, 1, 2d)(functions) == 2 :: "hi + 1" :: 2 :: HNil
+SelectFunctions.applyAll(1, hi)(functions) // won't compile
 SelectFunctions.applyAll(hi, 'a', 1)(functions) == "hi + 1" :: 1.0 :: 101 :: 2 :: 97 :: HNil
 ```
 
@@ -83,7 +82,7 @@ val functions = functions1 ::
       functions2 ::
       HNil
 
-FlattenFunctions.applyAll(1, "a")(functions) === 2 :: 1.0 :: HNil
+FlattenFunctions.applyAll(1, "a", 'a')(functions) === 2 :: 1.0 :: 99 :: HNil
 ```
 
 #### `EqualsIgnoringFields[T]`

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -6,7 +6,7 @@ object MyBuild extends Build{
   val projectName = "typeless"
   lazy val aRootProject = Project(id = projectName, base = file("."),
     settings = Seq(
-      version := "0.3.0",
+      version := "0.3.1",
       name := projectName,
       scalaVersion := "2.11.8",
       description := "It provides some extra shapeless functionallity",

--- a/src/main/scala/hlist/selectFunctions.scala
+++ b/src/main/scala/hlist/selectFunctions.scala
@@ -29,23 +29,13 @@ import shapeless.ops.coproduct.Inject
    * it applies the arguments to the functions for which all the arguments are present
    * it return an HList with the results
    */
+@annotation.implicitNotFound(msg = "Some functions are not satisfied \n Functions: ${FF} \n Arguments: ${Context}")
 trait SelectFunctions[FF <: HList, Context <: HList] {
   type Out <: HList
   def apply(fs: FF, context: Context)(implicit distinct: IsDistinctConstraint[Context]): Out
 }
 
-trait SelectFunctions0 {
-  implicit def hconsNotFound[F, FF <: HList, Context <: HList, Args <: HList, RT <: HList](
-    implicit
-    applyContext: SelectFunctions.Aux[FF, Context, RT]
-  ): SelectFunctions.Aux[F :: FF, Context, RT] = new SelectFunctions[F :: FF, Context] {
-    type Out = RT
-    def apply(fs: F :: FF, context: Context)(implicit distinct: IsDistinctConstraint[Context]) =
-      applyContext(fs.tail, context)
-  }
-
-}
-object SelectFunctions extends SelectFunctions0 {
+object SelectFunctions {
   type Aux[FF <: HList, Context <: HList, R <: HList] = SelectFunctions[FF, Context] { type Out = R }
   implicit def hcons[F, FF <: HList, Context <: HList, Args <: HList, R, RT <: HList](
     implicit

--- a/src/test/scala/crunch.scala
+++ b/src/test/scala/crunch.scala
@@ -37,9 +37,9 @@ class CrunchTests extends FunSuite with Matchers {
     val functions = functions1 ::
       functions2 ::
       HNil
-    val res = FlattenFunctions.applyAll(1, "a")(functions)
+    val res = FlattenFunctions.applyAll(1, "a", 'b')(functions)
     assert(
-      res === 2 :: 1.0 :: HNil
+      res === 2 :: 101 :: 100 :: 1.0 :: HNil
     )
   }
 

--- a/src/test/scala/selectFunctions.scala
+++ b/src/test/scala/selectFunctions.scala
@@ -21,44 +21,44 @@ package test
 import org.scalatest._
 import shapeless._
 import typeless.hlist._
+import shapeless.test.illTyped
 
 class SelectFunctionsTests extends FunSuite with Matchers {
   val functions =
-    { (x: String, i: Int, d: Double) => d.toInt * i } ::
-      { (x: String, i: Int) => s"$x + $i" } ::
+    { (x: String, i: Int) => s"$x + $i" } ::
+      { (x: String) => x.size } ::
       { (x: String, s: Char, i: Int) => i.toDouble } :: //is possible to have functions with the same context, they will all be used
       { (x: String, s: Char, i: Int) => s.toInt + i * 2 + x.size } ::
-      { (x: String) => x.size } ::
       { (x: Char) => x.toInt } ::
       HNil
 
   val hi = "hi"
   test("single argument") {
-    assert(
-      SelectFunctions.applyAll(hi)(functions) === 2 :: HNil
-    )
+    illTyped("""
+      SelectFunctions.applyAll(hi)(functions)
+    """)
   }
   test("two arguments") {
     assert(
-      SelectFunctions.applyAll(1, hi)(functions) === "hi + 1" :: 2 :: HNil
+      SelectFunctions.applyAll(1, hi)(functions.take(2)) === "hi + 1" :: 2 :: HNil
 
     )
   }
   test("three arguments") {
     assert(
-      SelectFunctions.applyAll(hi, 1, 2d)(functions) === 2 :: "hi + 1" :: 2 :: HNil
+      SelectFunctions.applyAll(hi, 1, 2d)(functions.take(2)) === "hi + 1" :: 2 :: HNil
     )
   }
-  test("different three arguments") {
-    assert(
-      SelectFunctions.applyAll(hi, 'a', 1)(functions) === "hi + 1" :: 1.0 :: 101 :: 2 :: 97 :: HNil
-    )
+  test("not enough arguments") {
+    illTyped("""
+      SelectFunctions.applyAll(hi, 'a')(functions)
+    """)
   }
 
   test("four arguments in different order") {
     // the order of the arguments doesn't matter
     assert(
-      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions) === 2 :: "hi + 1" :: 1.0 :: 101 :: 2 :: 97 :: HNil
+      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions) === "hi + 1" :: 2 :: 1.0 :: 101 :: 97 :: HNil
     )
   }
 

--- a/src/test/scala/selectFunctionsSeq.scala
+++ b/src/test/scala/selectFunctionsSeq.scala
@@ -24,17 +24,21 @@ import typeless.hlist._
 import shapeless.test.illTyped
 
 class ApplyAllSeqsTests extends FunSuite with Matchers {
+  val function1 = { (x: String, i: Int) => ("feature1" -> (x.size + i)) }
+  val function2 = { (x: String, i: Int) => ("feature2" -> i) }
+  val function3 = { (x: String, s: Char, i: Int) => ("feature3" -> (s.toInt + i + x.size)) }
+  val function4 = { (x: String, s: Char, i: Int) => ("feature4" -> (s.toInt + i * 2 + x.size)) }
+
   object functions1 {
     val functions =
-      { (x: String, i: Int) => ("feature1" -> (x.size + i)) } ::
-        { (x: String, i: Int) => ("feature2" -> i) } ::
-        HNil
+      function1 :: function2 :: HNil
   }
   object functions2 {
-    val functions =
-      { (x: String, s: Char, i: Int) => ("feature3" -> (s.toInt + i + x.size)) } ::
-        { (x: String, s: Char, i: Int) => ("feature4" -> (s.toInt + i * 2 + x.size)) } ::
-        HNil
+    val functions = function1 :: function2 :: function3 :: HNil
+  }
+
+  object functions3 {
+    val functions = function1 :: function2 :: function3 :: function4 :: HNil
   }
 
   val hi = "hi"
@@ -46,18 +50,18 @@ class ApplyAllSeqsTests extends FunSuite with Matchers {
   }
   test("won't compile if a function is not satisfied") {
     illTyped("""
-      SelectFunctions.applyAll(hi, 1, 2d)(functions1.functions :+ functions2.functions.head).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
+      SelectFunctions.applyAll(hi, 1, 2d)(functions2.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
     """)
   }
   test("different three arguments") {
     assert(
-      SelectFunctions.applyAll(hi, 'a', 1)(functions1.functions ++ functions2.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
+      SelectFunctions.applyAll(hi, 'a', 1)(functions3.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
     )
   }
   test("four arguments in different order") {
     // the order of the arguments doesn't matter
     assert(
-      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions1.functions ++ functions2.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
+      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions3.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
     )
   }
   test("can call with hlist") {

--- a/src/test/scala/selectFunctionsSeq.scala
+++ b/src/test/scala/selectFunctionsSeq.scala
@@ -21,41 +21,48 @@ package test
 import org.scalatest._
 import shapeless._
 import typeless.hlist._
+import shapeless.test.illTyped
 
 class ApplyAllSeqsTests extends FunSuite with Matchers {
-  val functions =
-    { (x: String, i: Int) => ("feature1" -> (x.size + i)) } ::
-      { (x: String, i: Int) => ("feature2" -> i) } ::
+  object functions1 {
+    val functions =
+      { (x: String, i: Int) => ("feature1" -> (x.size + i)) } ::
+        { (x: String, i: Int) => ("feature2" -> i) } ::
+        HNil
+  }
+  object functions2 {
+    val functions =
       { (x: String, s: Char, i: Int) => ("feature3" -> (s.toInt + i + x.size)) } ::
-      { (x: String, s: Char, i: Int) => ("feature4" -> (s.toInt + i * 2 + x.size)) } ::
-      HNil
+        { (x: String, s: Char, i: Int) => ("feature4" -> (s.toInt + i * 2 + x.size)) } ::
+        HNil
+  }
 
   val hi = "hi"
 
   test("two arguments") {
     assert(
-      SelectFunctions.applyAll(hi, 1)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
+      SelectFunctions.applyAll(hi, 1)(functions1.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
     )
   }
-  test("three arguments") {
-    assert(
-      SelectFunctions.applyAll(hi, 1, 2d)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
-    )
+  test("won't compile if a function is not satisfied") {
+    illTyped("""
+      SelectFunctions.applyAll(hi, 1, 2d)(functions1.functions :+ functions2.functions.head).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
+    """)
   }
   test("different three arguments") {
     assert(
-      SelectFunctions.applyAll(hi, 'a', 1)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
+      SelectFunctions.applyAll(hi, 'a', 1)(functions1.functions ++ functions2.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
     )
   }
   test("four arguments in different order") {
     // the order of the arguments doesn't matter
     assert(
-      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
+      SelectFunctions.applyAll(hi, 2d, 1, 'a')(functions1.functions ++ functions2.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1, "feature3" -> 100, "feature4" -> 101)
     )
   }
   test("can call with hlist") {
     assert(
-      SelectFunctions.applyAll(hi :: 1 :: HNil)(functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
+      SelectFunctions.applyAll(hi :: 1 :: HNil)(functions1.functions).to[Seq] === Seq("feature1" -> 3, "feature2" -> 1)
     )
   }
 


### PR DESCRIPTION
until now SelectFunctions was a partial function, but that's a dangerous
operation. In this commit SelectFunctions becomes total, i.e. it won't
compile if it cannot apply arguments to **all** the functions